### PR TITLE
Fix typo in README command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use this crate, you'll also need to install the [crank command line tool](htt
 
 From the crankstart directory where you found this README,
 
-    crank build --release --example hello_world
+    crank run --release --example hello_world
 
 Should launch the simulator and load in the hello_world sample.
 


### PR DESCRIPTION
Hey 👋

Love the project!
Just as I was getting started, I noticed what I think might be a small typo in the first README command.

It says `crank build` will "launch the simulator and load in the sample", but to do that I actually needed `crank run`

Let me know if I've misunderstood here 😅